### PR TITLE
Fixed Array palette color comparison

### DIFF
--- a/addons/eye_dropper/eye_dropper.gdshader
+++ b/addons/eye_dropper/eye_dropper.gdshader
@@ -71,6 +71,27 @@ int compare_floats(float a, float b) {
 }
 
 /**
+ * Compares two colors ([param a] and [param b]), and tells if they are
+ * approximately equal, based on an epsilon of [code]0.001[/code].
+ * If the colors match, [code]true[/code] is returned, else, this function
+ * returns [code]false[/code].
+ * This code was adapted from
+ * [url=https://forum.godotengine.org/t/shader-wont-work-during-runtime/53299/4]Calinou's post on the Godot forum[/url].
+ */
+bool color_is_approx_equal(vec4 a, vec4 b) {
+	if (
+	    a.r >= b.r - 0.001 && a.r <= b.r + 0.001 &&
+	    a.g >= b.g - 0.001 && a.g <= b.g + 0.001 &&
+	    a.b >= b.b - 0.001 && a.b <= b.b + 0.001 && 
+	    a.a >= b.a - 0.001 && a.a <= b.a + 0.001
+	) {
+		return true;
+	}
+	
+	return false;
+}
+
+/**
  * The [code]color_is_transparent[/code] function is a utility function that
  * returns a [code]bool[/code] indicating if the received [param color] is
  * fully transparent.
@@ -177,7 +198,7 @@ int find_color_in_palette_array(vec4 color, vec4[max_palette_array_size] palette
 	for(int i = 0; i < safe_palette_array_size; i++) {
 		vec4 palette_color = palette[i];
 		
-		if(color == palette_color) {
+		if(color_is_approx_equal(color, palette_color)) {
 			return i;
 		}
 		if(color_is_transparent(color) && color_is_transparent(palette_color)) {

--- a/addons/eye_dropper/eye_dropper.gdshader
+++ b/addons/eye_dropper/eye_dropper.gdshader
@@ -4,7 +4,7 @@ shader_type canvas_item;
  * The [code]max_palette_array_size[/code] constant specifies how much colors the [code]input_palette_array[/code] and [code]output_palette_array[/code] properties should store at maximum.
  * Since the size of arrays in shaders must be constant, this can't be exported to be edited in the editor, so it is expected that you hardcode this manually to attend your needs.
  */
-const uint max_palette_array_size = uint(4);
+const uint max_palette_array_size = uint(8);
 
 /**
  * The [code]palette_array_size[/code] property stores how much colors there actually are in the palette arrays.

--- a/test/manual/array_palette_swapping/array_palette_swapping.tscn
+++ b/test/manual/array_palette_swapping/array_palette_swapping.tscn
@@ -1,0 +1,73 @@
+[gd_scene load_steps=4 format=3 uid="uid://btgv6y4oqv6b8"]
+
+[ext_resource type="Texture2D" uid="uid://c151c68kdwt6m" path="res://test/resources/dog_sprite.png" id="1_871wc"]
+[ext_resource type="Material" uid="uid://e18gy65uooye" path="res://test/manual/array_palette_swapping/shader_material.tres" id="2_g41dt"]
+[ext_resource type="Texture2D" uid="uid://buv2lag6lwfci" path="res://test/resources/dog_sprite_palette1.png" id="3_5egc2"]
+
+[node name="ArrayPaletteSwapping" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Container" type="CenterContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Row" type="HBoxContainer" parent="Container"]
+layout_mode = 2
+
+[node name="Column1" type="VBoxContainer" parent="Container/Row"]
+layout_mode = 2
+
+[node name="Title" type="Label" parent="Container/Row/Column1"]
+custom_minimum_size = Vector2(77, 0)
+layout_mode = 2
+theme_override_font_sizes/font_size = 10
+text = "Original Sprite"
+horizontal_alignment = 1
+
+[node name="CanvasItem" type="TextureRect" parent="Container/Row/Column1"]
+layout_mode = 2
+texture = ExtResource("1_871wc")
+expand_mode = 4
+stretch_mode = 5
+
+[node name="Column2" type="VBoxContainer" parent="Container/Row"]
+layout_mode = 2
+
+[node name="Title" type="Label" parent="Container/Row/Column2"]
+custom_minimum_size = Vector2(77, 0)
+layout_mode = 2
+theme_override_font_sizes/font_size = 10
+text = "Shader Applied"
+horizontal_alignment = 1
+
+[node name="CanvasItem" type="TextureRect" parent="Container/Row/Column2"]
+material = ExtResource("2_g41dt")
+layout_mode = 2
+texture = ExtResource("1_871wc")
+expand_mode = 4
+stretch_mode = 5
+
+[node name="Column3" type="VBoxContainer" parent="Container/Row"]
+layout_mode = 2
+
+[node name="Title" type="Label" parent="Container/Row/Column3"]
+custom_minimum_size = Vector2(77, 0)
+layout_mode = 2
+theme_override_font_sizes/font_size = 10
+text = "Expected Result"
+horizontal_alignment = 1
+
+[node name="CanvasItem" type="TextureRect" parent="Container/Row/Column3"]
+layout_mode = 2
+texture = ExtResource("3_5egc2")
+expand_mode = 4
+stretch_mode = 5

--- a/test/manual/array_palette_swapping/shader_material.tres
+++ b/test/manual/array_palette_swapping/shader_material.tres
@@ -1,0 +1,9 @@
+[gd_resource type="ShaderMaterial" load_steps=2 format=3 uid="uid://e18gy65uooye"]
+
+[ext_resource type="Shader" path="res://addons/eye_dropper/eye_dropper.gdshader" id="1_cbin0"]
+
+[resource]
+shader = ExtResource("1_cbin0")
+shader_parameter/palette_array_size = 8
+shader_parameter/input_palette_array = PackedColorArray(0, 0, 0, 1, 0.188235, 0.176471, 0.2, 1, 0.603922, 0.541176, 0.541176, 1, 0.705882, 0.658824, 0.631373, 1, 0.8, 0.784314, 0.713726, 1, 0.901961, 0.898039, 0.803922, 1, 1, 1, 1, 1, 0, 0, 0, 0)
+shader_parameter/output_palette_array = PackedColorArray(0.0313726, 0.109804, 0.0823529, 1, 0.737255, 0.423529, 0.145098, 1, 0.203922, 0.305882, 0.254902, 1, 0.227451, 0.352941, 0.25098, 1, 0.345098, 0.505882, 0.341176, 1, 0.639216, 0.694118, 0.541176, 1, 0.854902, 0.843137, 0.803922, 1, 1, 0.764706, 0.721569, 1)


### PR DESCRIPTION
## Overview
This Pull Request brings small modifications to the `eye_dropper.gdshader` file, which were necessary in order to fix a bug that was making the color swapping through `Array` palettes not happen as it should when the project is executing.

Apparently, this bug was happening due to how the comparison of colors from `PackedColorArrays` was being handled. This may be related to the floating point imprecision, discussed in this [Godot forum topic](https://forum.godotengine.org/t/shader-wont-work-during-runtime/53299).

In order to fix this issue, a code snippet similar to [the one proposed by Calinou](https://forum.godotengine.org/t/shader-wont-work-during-runtime/53299/4) in that same topic was used.

## Related Issues
fixes #1 

## Checklist
- [X] This code follows the project's coding style.
- [X] I have tested my changes in Godot 4.3.
- [X] I have updated the documentation.
- [X] I have added tests.
- [X] This PR does not introduce new warnings or errors.

## What was changed
With this PR, a new manual test scene was also added in order to make it easier to test the issue addressed. With that same purpose, the default `max_palette_array_size` const had its value altered to `8`, to allow this new test scene to test all colors it needed.
Finally, this PR has as its main modification the addition of the new `color_is_approx_equal` function, which handles floating point imprecisions better when testing whether two colors are equal or not. This new function is now used in the `find_color_in_palette_array` function, instead of trying to compare two `float` values directly with a `==` operator.

## How to Test
The modifications of this PR can be tested manually with the new `array_palette_swapping` manual test.
